### PR TITLE
Fix string encoding problem (Python 3)

### DIFF
--- a/mapzen/api.py
+++ b/mapzen/api.py
@@ -220,7 +220,7 @@ class MapzenAPI(object):
         try:
             request = self._prepare_request(endpoint, params)
             response = urlopen(request)
-            return json.loads(response.read(), encoding='utf-8')
+            return json.loads(response.read().decode('utf-8'))
         except HTTPError as e:
             self._raise_exceptions_for_status(e)
         except Exception as e:


### PR DESCRIPTION
Previously, when doing a reverse lookup, this code would through the exception "the JSON object must be str, not 'bytes'".

Note: I haven't tested this change on Python 2.